### PR TITLE
Handle missing pygetwindow gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ai_assistant
+This repository contains a simple desktop assistant using PyQt5.
+Pygetwindow is optional; if unavailable, the foreground window name defaults to "Unknown Window".

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -1,6 +1,9 @@
 import time
 import psutil
-import pygetwindow as gw
+try:
+    import pygetwindow as gw
+except Exception:  # noqa: E722 - broadly handle any import problem
+    gw = None
 import keyboard
 import mouse
 from collections import deque
@@ -31,7 +34,10 @@ class SystemMonitor:
         self._prune_history()
         timestamp = time.time()
         try:
-            fg_window = gw.getActiveWindow().title
+            if gw:
+                fg_window = gw.getActiveWindow().title
+            else:
+                fg_window = "Unknown Window"
         except Exception:
             fg_window = "Unknown Window"
         processes = {p.pid: p.name() for p in psutil.process_iter(["name"])}


### PR DESCRIPTION
## Summary
- allow `system_monitor.py` to run even if `pygetwindow` fails to import
- update README with short project description and note about optional `pygetwindow`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684bb3a0136c8329b38da894c8b99d78