### PR TITLE
Add draggable floating window

### DIFF
--- a/floating_ui.py
+++ b/floating_ui.py
@@ -13,10 +13,31 @@ class FloatingWindow(QtWidgets.QWidget):
         )
         self.resize(250, 120)
 
+        self._drag_pos = None
+
         layout = QtWidgets.QVBoxLayout(self)
         self.label = QtWidgets.QLabel("", self)
         self.label.setWordWrap(True)
+        self.label.setAlignment(QtCore.Qt.AlignCenter)
         layout.addWidget(self.label)
+
+        # Show an initial friendly message
+        self.display_message("👋 I'm your assistant! (Drag me around)")
 
     def display_message(self, text):
         self.label.setText(text)
+
+    # -- Drag Support -----------------------------------------------------
+    def mousePressEvent(self, event):
+        if event.button() == QtCore.Qt.LeftButton:
+            self._drag_pos = event.globalPos() - self.frameGeometry().topLeft()
+            event.accept()
+
+    def mouseMoveEvent(self, event):
+        if event.buttons() & QtCore.Qt.LeftButton and self._drag_pos:
+            self.move(event.globalPos() - self._drag_pos)
+            event.accept()
+
+    def mouseReleaseEvent(self, event):
+        self._drag_pos = None
+        event.accept()


### PR DESCRIPTION
## Summary
- allow moving the assistant window by dragging anywhere
- center initial text and show a friendly greeting

## Testing
- `python -m py_compile floating_ui.py`
- `python -m py_compile main.py`
- `pytest -q` *(fails: _tkinter.TclError: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_684bb62f73e88329a81fae9ef8b31f5f