### PR TITLE
Add snapshot logging and JSON summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The `SystemMonitor` component now tracks:
 - Keyboard and mouse activity.
 - Optional file modifications using `watchdog`.
 
+Snapshots are written to `activity_log.jsonl` in the repository root.
+
 If the window information libraries are unavailable, the monitor falls back to `"Unknown Window"`.
 
 Legacy test utilities like `test_script.py` and the separate `key_logger.py` have been removed.

--- a/agent.py
+++ b/agent.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import json
 
 from system_monitor import SystemMonitor
 from llm_client import OllamaClient
@@ -25,8 +26,8 @@ class ClippyAgent:
 
     def _loop(self):
         while not self._stop.is_set():
-            self.monitor.capture_snapshot()
-            summary = self.monitor.summarize()
+            snapshot = self.monitor.capture_snapshot()
+            summary = json.dumps(snapshot)
             response = self.llm.query(summary)
             self.window.display_message(response)
             for _ in range(self.poll_interval):

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -4,6 +4,7 @@ import sys
 import time
 from collections import deque
 from datetime import datetime
+import json
 import threading
 
 import psutil
@@ -60,9 +61,10 @@ except Exception:  # noqa: E722 - broadly handle any import problem
 class SystemMonitor:
     """Tracks active window, inputs, clipboard, screenshots and optional file events."""
 
-    def __init__(self, history_seconds=30, watch_paths=None, screenshot_interval=5):
+    def __init__(self, history_seconds=30, watch_paths=None, screenshot_interval=5, log_path="activity_log.jsonl"):
         self.history_seconds = history_seconds
         self.events = deque()
+        self.log_path = log_path
 
         self.screenshot_interval = screenshot_interval
         self._stop = threading.Event()
@@ -229,12 +231,54 @@ class SystemMonitor:
         processes = {p.pid: p.name() for p in psutil.process_iter(["name"])}
         self._record(f"Running apps: {list(processes.values())[:5]}")
 
+        snapshot = self.to_json()
+        self._append_to_log(snapshot)
+        return snapshot
+
     def summarize(self):
         """Return a plain-language summary of recent events."""
         self._prune_history()
         lines = [e[1] for e in self.events]
         summary = "\n".join(lines)
         return f"Recent activity ({datetime.now().strftime('%H:%M:%S')}):\n{summary}"
+
+    def to_json(self):
+        """Return a structured summary of recent events."""
+        self._prune_history()
+
+        title, app = self._get_active_window_info()
+
+        clipboard = [
+            e[1][13:-1]
+            for e in self.events
+            if e[1].startswith("Copied text:")
+        ]
+        inputs = [
+            e[1]
+            for e in self.events
+            if e[1].startswith("Pressed key") or e[1].startswith("Mouse")
+        ]
+        ocr = [
+            e[1][12:]
+            for e in self.events
+            if e[1].startswith("Screen OCR:")
+        ]
+
+        return {
+            "timestamp": datetime.now().isoformat(),
+            "active_window": {"title": title, "app": app},
+            "clipboard": clipboard,
+            "input_events": inputs,
+            "ocr_snippets": ocr,
+        }
+
+    def _append_to_log(self, data):
+        try:
+            with open(self.log_path, "a", encoding="utf-8") as f:
+                json.dump(data, f)
+                f.write("\n")
+        except Exception:
+            pass
 
     def __del__(self):
         self._stop.set()


### PR DESCRIPTION
## Summary
- add `SystemMonitor.to_json` for structured snapshots
- log snapshots to `activity_log.jsonl`
- send JSON snapshot to the LLM in `ClippyAgent`
- document log file location in README

## Testing
- `python -m py_compile agent.py ai_agent.py assistant_core.py code_assistant.py floating_ui.py gui_interface.py llm_client.py main.py system_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_684bd048dac08329a3070d5b21f568a3