### PR TITLE
Improve mouse monitoring and add tests

### DIFF
--- a/system_monitor.py
+++ b/system_monitor.py
@@ -113,7 +113,11 @@ class SystemMonitor:
         self._record(f"Pressed key: {event.name}")
 
     def _on_mouse(self, event):
-        self._record(f"Mouse {event.event_type}")
+        event_type = getattr(event, "event_type", None) or event.__class__.__name__
+        message = f"Mouse {event_type}"
+        if hasattr(event, "delta"):
+            message += f" delta={event.delta}"
+        self._record(message)
 
     def _prune_history(self):
         cutoff = time.time() - self.history_seconds

--- a/tests/test_system_monitor.py
+++ b/tests/test_system_monitor.py
@@ -1,0 +1,46 @@
+import unittest
+from collections import deque
+
+from system_monitor import SystemMonitor
+
+
+class DummyWheelEvent:
+    def __init__(self, delta=1):
+        self.event_type = "wheel"
+        self.delta = delta
+
+
+class DummyMoveEvent:
+    def __init__(self):
+        self.event_type = "move"
+
+
+class SystemMonitorTest(unittest.TestCase):
+    def _make_monitor(self):
+        monitor = SystemMonitor.__new__(SystemMonitor)
+        monitor.events = deque()
+        monitor.history_seconds = 30
+        import threading
+        monitor._stop = threading.Event()
+        monitor._screenshot_thread = None
+        monitor.observer = None
+        return monitor
+
+    def test_wheel_event_no_exception(self):
+        monitor = self._make_monitor()
+        event = DummyWheelEvent(delta=5)
+        monitor._on_mouse(event)
+        self.assertTrue(monitor.events)
+        self.assertIn("wheel", monitor.events[-1][1])
+        self.assertIn("delta=5", monitor.events[-1][1])
+
+    def test_move_event_no_exception(self):
+        monitor = self._make_monitor()
+        event = DummyMoveEvent()
+        monitor._on_mouse(event)
+        self.assertTrue(monitor.events)
+        self.assertIn("move", monitor.events[-1][1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle generic mouse events in `SystemMonitor._on_mouse`
- record wheel delta if present
- add unit tests for mouse wheel and move events

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bd04a43cc8329b2ccde9318501789