### PR TITLE
Improve SystemMonitor cleanup

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -22,6 +22,7 @@ class ClippyAgent:
     def stop(self):
         self._stop.set()
         self.thread.join()
+        self.monitor.stop()
 
     def _loop(self):
         while not self._stop.is_set():


### PR DESCRIPTION
## Summary
- keep references to keyboard and mouse hooks
- provide an explicit `stop` method for `SystemMonitor`
- call the monitor cleanup from `ClippyAgent.stop`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bd04b421483298c20f238caf7ca67