### PR TITLE
Add LLM-powered error reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Snapshots are written to `activity_log.jsonl` in the repository root.
 If the window information libraries are unavailable, the monitor falls back to `"Unknown Window"`.
 
 Legacy test utilities like `test_script.py` and the separate `key_logger.py` have been removed.
+
+## Error reporting
+
+Running `main.py` is now wrapped with an `ErrorReporter`. When an
+exception is raised, the full traceback is sent to a local Ollama
+instance and the model explains the problem. The traceback and LLM
+response are appended to `error_report.txt` so you can review past
+failures.

--- a/error_handler.py
+++ b/error_handler.py
@@ -1,0 +1,54 @@
+import json
+import traceback
+from collections import deque
+from datetime import datetime
+from typing import Deque, Dict, Any
+
+import requests
+
+
+class ErrorReporter:
+    """Send exceptions to an LLM and log the explanation."""
+
+    def __init__(
+        self,
+        model: str = "dolphin-mixtral:8x7b",
+        url: str = "http://localhost:11434/api/chat",
+        log_path: str = "error_report.txt",
+        memory: int = 6,
+    ) -> None:
+        self.model = model
+        self.url = url
+        self.log_path = log_path
+        self._messages: Deque[Dict[str, Any]] = deque(maxlen=memory)
+        self._messages.append(
+            {
+                "role": "system",
+                "content": "You help explain Python exceptions succinctly.",
+            }
+        )
+
+    def _query_llm(self, error: str) -> str:
+        self._messages.append({"role": "user", "content": f"Explain this Python error:\n{error}"})
+        payload = {"model": self.model, "messages": list(self._messages)}
+        try:
+            resp = requests.post(self.url, json=payload, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+            reply = data.get("message", {}).get("content", "")
+        except Exception as exc:  # noqa: E722 - broad catch to avoid recursion
+            reply = f"Failed to query LLM: {exc}"
+        self._messages.append({"role": "assistant", "content": reply})
+        return reply
+
+    def handle_exception(self) -> None:
+        err = traceback.format_exc()
+        explanation = self._query_llm(err)
+        print(explanation)
+        try:
+            with open(self.log_path, "a", encoding="utf-8") as f:
+                ts = datetime.now().isoformat()
+                f.write(f"--- {ts} ---\n{err}\n{explanation}\n\n")
+        except Exception:
+            pass
+

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import sys
 from PyQt5 import QtWidgets
 from floating_ui import FloatingWindow
 from agent import ClippyAgent
+from error_handler import ErrorReporter
 
 def main():
     app = QtWidgets.QApplication(sys.argv)
@@ -16,4 +17,9 @@ def main():
     sys.exit(exit_code)
 
 if __name__ == "__main__":
-    main()
+    reporter = ErrorReporter()
+    try:
+        main()
+    except Exception:
+        reporter.handle_exception()
+

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,30 @@
+import json
+import os
+import builtins
+from unittest import mock
+from error_handler import ErrorReporter
+
+
+def test_handle_exception_writes_log(tmp_path):
+    log_file = tmp_path / "err.txt"
+    reporter = ErrorReporter(log_path=str(log_file), memory=3)
+
+    fake_response = mock.Mock()
+    fake_response.json.return_value = {"message": {"content": "oops"}}
+    fake_response.headers = {"content-type": "application/json"}
+    fake_response.raise_for_status.return_value = None
+
+    with mock.patch("requests.post", return_value=fake_response):
+        try:
+            raise ValueError("bad")
+        except Exception:
+            reporter.handle_exception()
+
+    assert log_file.exists()
+    text = log_file.read_text()
+    assert "ValueError" in text
+    assert "oops" in text
+
+    # Ensure memory deque keeps messages within limit
+    assert len(reporter._messages) <= 3
+


### PR DESCRIPTION
## Summary
- wrap `main.py` with an `ErrorReporter`
- implement `error_handler.py` for sending tracebacks to Ollama
- log explanations in `error_report.txt`
- document the new feature
- add tests for the reporter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd282aed0832995a5b71e89a3d55e