### PR TITLE
Add memory buffer to LLM client

### DIFF
--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,19 @@
+import json
+from unittest import mock
+from llm_client import OllamaClient
+
+
+def test_memory_limit():
+    client = OllamaClient(memory=3)
+
+    fake_response = mock.Mock()
+    fake_response.json.return_value = {"message": {"content": "reply"}}
+    fake_response.headers = {"content-type": "application/json"}
+    fake_response.raise_for_status.return_value = None
+
+    with mock.patch("requests.post", return_value=fake_response):
+        for i in range(5):
+            client.query(f"msg {i}")
+
+    # 1 system message + last 3 user/assistant pairs -> length should be <= 7
+    assert len(client._messages) <= 7


### PR DESCRIPTION
## Summary
- keep conversation context for the Ollama client using a bounded deque
- test that the LLM client's memory never exceeds the configured limit

## Testing
- `pip install requests psutil keyboard mouse`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd74b9c448329b03ae6b92850e6ae