### PR TITLE
Add text input for assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ exception is raised, the full traceback is sent to a local Ollama
 instance and the model explains the problem. The traceback and LLM
 response are appended to `error_report.txt` so you can review past
 failures.
+
+## Interactive commands
+
+The assistant window now includes a small text box. Type a prompt and press
+Enter to send it directly to the LLM. The reply appears in the floating window
+so you can interact with the assistant in real time without using your
+microphone.

--- a/agent.py
+++ b/agent.py
@@ -34,3 +34,8 @@ class ClippyAgent:
                 if self._stop.is_set():
                     break
                 time.sleep(1)
+
+    def handle_text(self, text):
+        """Process text input by querying the LLM and showing the reply."""
+        reply = self.llm.query(text)
+        self.window.display_message(reply)

--- a/floating_ui.py
+++ b/floating_ui.py
@@ -3,8 +3,9 @@ from PyQt5 import QtWidgets, QtCore
 class FloatingWindow(QtWidgets.QWidget):
     """Small window that stays on top and shows messages."""
 
-    def __init__(self):
+    def __init__(self, on_submit=None):
         super().__init__()
+        self.on_submit = on_submit
         self.setWindowTitle("AI Assistant")
         self.setWindowFlags(
             QtCore.Qt.Tool
@@ -20,12 +21,21 @@ class FloatingWindow(QtWidgets.QWidget):
         self.label.setWordWrap(True)
         self.label.setAlignment(QtCore.Qt.AlignCenter)
         layout.addWidget(self.label)
+        self.input = QtWidgets.QLineEdit(self)
+        self.input.returnPressed.connect(self._send_input)
+        layout.addWidget(self.input)
 
         # Show an initial friendly message
         self.display_message("👋 I'm your assistant! (Drag me around)")
 
     def display_message(self, text):
         self.label.setText(text)
+
+    def _send_input(self):
+        text = self.input.text().strip()
+        if text and self.on_submit:
+            self.on_submit(text)
+        self.input.clear()
 
     # -- Drag Support -----------------------------------------------------
     def mousePressEvent(self, event):

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ def main():
     window.show()
 
     agent = ClippyAgent(window)
+    window.on_submit = agent.handle_text
     agent.start()
 
     exit_code = app.exec_()


### PR DESCRIPTION
## Summary
- replace voice command feature with simple text input box
- update `ClippyAgent` to handle typed text instead of voice
- wire `FloatingWindow` to send text to the agent
- document interactive commands in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bdae2878083299b51907b9f769aa5