### PR TITLE
Add customizable system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Enter to send it directly to the LLM. The reply appears in the floating window
 so you can interact with the assistant in real time without using your
 microphone.
 
+### Custom system prompt
+
+`OllamaClient` now accepts a `system_prompt` argument. This optional string
+sets the initial system message used for every conversation. If omitted, the
+client defaults to "You are a helpful assistant." Passing a different value lets
+you customize the assistant's personality.
+
 ## Memos and process scans
 
 Use `SystemMonitor.save_screen_memo()` to capture on-screen text and save it in the `ai_memos` folder. The helper `memo_utils.save_memo()` writes a timestamped file with a descriptive name.

--- a/agent.py
+++ b/agent.py
@@ -12,7 +12,12 @@ class ClippyAgent:
         self.window = window
         # Monitor the current directory for file changes as an example
         self.monitor = SystemMonitor(watch_paths=["."])
-        self.llm = OllamaClient()
+        self.llm = OllamaClient(
+            system_prompt=(
+                "You are Clippy, the quirky paperclip assistant from the 90s. "
+                "Give short, playful tips in a lighthearted tone."
+            )
+        )
         self.poll_interval = poll_interval
         self._stop = threading.Event()
 

--- a/llm_client.py
+++ b/llm_client.py
@@ -12,13 +12,12 @@ class OllamaClient:
         model: str = "openhermes",
         url: str = "http://localhost:11434/api/chat",
         memory: int = 5,
+        system_prompt: str = "You are a helpful assistant.",
     ) -> None:
         self.model = model
         self.url = url
         self._messages: Deque[Dict[str, Any]] = deque(maxlen=memory)
-        self._messages.append(
-            {"role": "system", "content": "You are a helpful assistant."}
-        )
+        self._messages.append({"role": "system", "content": system_prompt})
 
     def query(self, prompt: str, timeout: int = 60) -> str:
         """Send a prompt and update conversation history."""

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -17,3 +17,13 @@ def test_memory_limit():
 
     # 1 system message + last 3 user/assistant pairs -> length should be <= 7
     assert len(client._messages) <= 7
+
+
+def test_default_system_prompt():
+    client = OllamaClient()
+    assert client._messages[0]["content"] == "You are a helpful assistant."
+
+
+def test_custom_system_prompt():
+    client = OllamaClient(system_prompt="be quirky")
+    assert client._messages[0]["content"] == "be quirky"


### PR DESCRIPTION
## Summary
- allow customizing Ollama system prompt
- make Clippy's startup quirkier
- document system prompt option in README
- test default vs. custom prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be1aa37c08329b7f2ad199d381b41