### PR TITLE
Make tesseract path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ microphone.
 Use `SystemMonitor.save_screen_memo()` to capture on-screen text and save it in the `ai_memos` folder. The helper `memo_utils.save_memo()` writes a timestamped file with a descriptive name.
 
 `SystemMonitor.scan_processes()` performs a simple heuristic check for suspicious processes based on keywords like "malware" or "virus".
+
+### OCR configuration
+
+Screen text extraction relies on Tesseract. The monitor will attempt to locate
+the `tesseract` executable automatically. If detection fails, set the
+`TESSERACT_CMD` environment variable to the full path before running the
+assistant:
+
+```bash
+export TESSERACT_CMD=/path/to/tesseract
+```

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -54,7 +54,11 @@ except Exception:  # noqa: E722 - broadly handle any import problem
 
 try:
     import pytesseract
-    pytesseract.pytesseract.tesseract_cmd = r"C:\\Program Files\\Tesseract-OCR\\tesseract.exe"
+    import shutil
+    import os
+    cmd = os.environ.get("TESSERACT_CMD") or shutil.which("tesseract")
+    if cmd:
+        pytesseract.pytesseract.tesseract_cmd = cmd
 except Exception:  # noqa: E722 - broadly handle any import problem
     pytesseract = None
 

--- a/tests/test_system_monitor.py
+++ b/tests/test_system_monitor.py
@@ -1,5 +1,6 @@
 import unittest
 from collections import deque
+from unittest import mock
 
 from system_monitor import SystemMonitor
 
@@ -65,6 +66,21 @@ class SystemMonitorTest(unittest.TestCase):
 
         names = [p["name"] for p in suspicious]
         self.assertIn("bad-virus.exe", names)
+
+    def test_env_var_sets_tesseract_path(self):
+        import importlib
+        import sys
+        import types
+        import os
+
+        dummy = types.SimpleNamespace(pytesseract=types.SimpleNamespace())
+        with mock.patch.dict(sys.modules, {"pytesseract": dummy}):
+            with mock.patch.dict(os.environ, {"TESSERACT_CMD": "/opt/custom"}):
+                mod = importlib.reload(importlib.import_module("system_monitor"))
+                self.assertEqual(
+                    dummy.pytesseract.tesseract_cmd, "/opt/custom"
+                )
+        importlib.reload(mod)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow configuring Tesseract path with `TESSERACT_CMD`
- document how to override the detection
- test that the environment variable is respected

## Testing
- `pip install psutil requests keyboard mouse`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be1afb5248329b67563cf5462287c