### PR TITLE
Improve memo saving and UI logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ failures.
 ## Interactive commands
 
 The assistant window now includes a small text box. Type a prompt and press
-Enter to send it directly to the LLM. The reply appears in the floating window
-so you can interact with the assistant in real time without using your
-microphone.
+Enter to send it directly to the LLM. Replies accumulate in the floating window
+so you have a scrollable running log of the conversation. The window can now be
+resized like a normal application.
 
 ### Custom system prompt
 
@@ -42,6 +42,6 @@ you customize the assistant's personality.
 
 ## Memos and process scans
 
-Use `SystemMonitor.save_screen_memo()` to capture on-screen text and save it in the `ai_memos` folder. The helper `memo_utils.save_memo()` writes a timestamped file with a descriptive name. Typing **memo**, **remember**, or **note** in the assistant's text box automatically triggers this capture.
+Use `SystemMonitor.save_screen_memo()` to capture on-screen text and save it in the `ai_memos` folder. The helper `memo_utils.save_memo()` writes a timestamped file with a descriptive name. Typing **memo**, **remember**, or **note** in the assistant's text box automatically triggers this capture. Pass `allow_empty=True` to `save_screen_memo` to force a memo even when OCR text can't be captured (e.g. if dependencies are missing).
 
 `SystemMonitor.scan_processes()` performs a simple heuristic check for suspicious processes based on keywords like "malware" or "virus".

--- a/agent.py
+++ b/agent.py
@@ -48,6 +48,6 @@ class ClippyAgent:
         lower = text.lower()
         if any(k in lower for k in ["memo", "remember", "note"]):
             try:
-                self.monitor.save_screen_memo(label=text)
+                self.monitor.save_screen_memo(label=text, allow_empty=True)
             except Exception:
                 pass

--- a/floating_ui.py
+++ b/floating_ui.py
@@ -8,19 +8,16 @@ class FloatingWindow(QtWidgets.QWidget):
         self.on_submit = on_submit
         self.setWindowTitle("AI Assistant")
         self.setWindowFlags(
-            QtCore.Qt.Tool
-            | QtCore.Qt.WindowStaysOnTopHint
-            | QtCore.Qt.FramelessWindowHint
+            QtCore.Qt.Window | QtCore.Qt.WindowStaysOnTopHint
         )
-        self.resize(250, 120)
+        self.resize(300, 200)
 
         self._drag_pos = None
 
         layout = QtWidgets.QVBoxLayout(self)
-        self.label = QtWidgets.QLabel("", self)
-        self.label.setWordWrap(True)
-        self.label.setAlignment(QtCore.Qt.AlignCenter)
-        layout.addWidget(self.label)
+        self.log_box = QtWidgets.QTextEdit(self)
+        self.log_box.setReadOnly(True)
+        layout.addWidget(self.log_box)
         self.input = QtWidgets.QLineEdit(self)
         self.input.returnPressed.connect(self._send_input)
         layout.addWidget(self.input)
@@ -29,7 +26,10 @@ class FloatingWindow(QtWidgets.QWidget):
         self.display_message("👋 I'm your assistant! (Drag me around)")
 
     def display_message(self, text):
-        self.label.setText(text)
+        self.log_box.append(text)
+        self.log_box.verticalScrollBar().setValue(
+            self.log_box.verticalScrollBar().maximum()
+        )
 
     def _send_input(self):
         text = self.input.text().strip()

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -374,9 +374,21 @@ class SystemMonitor:
                 return ""
         return ""
 
-    def save_screen_memo(self, label=None, directory="ai_memos"):
-        """Capture screen text and save to a memo file."""
+    def save_screen_memo(self, label=None, directory="ai_memos", allow_empty=False):
+        """Capture screen text and save to a memo file.
+
+        Parameters
+        ----------
+        label : str, optional
+            Optional label for the memo filename.
+        directory : str, default "ai_memos"
+            Directory where the memo will be created.
+        allow_empty : bool, default False
+            When True, a memo file is created even if no text is captured.
+        """
         text = self.capture_screen_text()
+        if not text and allow_empty:
+            text = "No screen text captured"
         if text:
             from memo_utils import save_memo
             save_memo(text, label, directory)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -24,8 +24,10 @@ def _make_monitor(tmp_path):
     monitor.capture_snapshot = lambda: {}
     monitor.capture_screen_text = lambda: "dummy text"
 
-    def save_screen_memo(label=None, directory="ai_memos"):
-        return SystemMonitor.save_screen_memo(monitor, label, directory=tmp_path)
+    def save_screen_memo(label=None, directory="ai_memos", allow_empty=False):
+        return SystemMonitor.save_screen_memo(
+            monitor, label, directory=tmp_path, allow_empty=allow_empty
+        )
 
     monitor.save_screen_memo = save_screen_memo
     return monitor

--- a/tests/test_system_monitor.py
+++ b/tests/test_system_monitor.py
@@ -1,5 +1,6 @@
 import unittest
 from collections import deque
+from pathlib import Path
 
 from system_monitor import SystemMonitor
 
@@ -40,6 +41,18 @@ class SystemMonitorTest(unittest.TestCase):
         monitor._on_mouse(event)
         self.assertTrue(monitor.events)
         self.assertIn("move", monitor.events[-1][1])
+
+    def test_save_screen_memo_allow_empty_creates_file(self):
+        import tempfile
+        monitor = self._make_monitor()
+        monitor.capture_screen_text = lambda: ""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            success = monitor.save_screen_memo(directory=tmpdir, allow_empty=True)
+            self.assertTrue(success)
+            files = list(Path(tmpdir).iterdir())
+            self.assertTrue(files)
+            text = files[0].read_text()
+            self.assertIn("No screen text captured", text)
 
     def test_scan_processes_monkeypatch(self):
         monitor = self._make_monitor()


### PR DESCRIPTION
## Summary
- support writing blank memos with `allow_empty` option
- display conversation history in scrollable window and allow resizing
- update Clippy agent to pass `allow_empty`
- document new behaviour in README
- test saving empty memos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be40c8cec83299bdaf149b3635508