### PR TITLE
Add Discord bot integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Use pip to install the required packages:
 pip install -r requirements.txt
 ```
 
+You can optionally set the `TESSERACT_CMD` environment variable if Tesseract OCR is installed in a non-standard location.
 
 The `SystemMonitor` component now tracks:
 
@@ -55,6 +56,9 @@ Use `SystemMonitor.save_screen_memo()` to capture on-screen text and save it in 
 
 `SystemMonitor.scan_processes()` performs a simple heuristic check for suspicious processes based on keywords like "malware" or "virus".
 
+## Discord Bot
+Run `discord_bot.py` to enable a chat interface in Discord.
+Set the `DISCORD_TOKEN` environment variable with your bot token before running.
 
 ## License
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -1,0 +1,39 @@
+# Discord Bot for AI Assistant Project
+# Application ID: 311019517365190656
+# Public Key: acf2dda637df5e9d50726ab5c4b886eb9e9b616927ba209afbaf54b449b067be
+
+import os
+import discord
+from llm_client import OllamaClient
+
+TOKEN = os.getenv("DISCORD_TOKEN")
+
+intents = discord.Intents.default()
+client = discord.Client(intents=intents)
+llm = OllamaClient()
+
+async def handle_message(message: discord.Message) -> None:
+    """Process a Discord message."""
+    if message.author.bot:
+        return
+
+    content = message.content
+    if "hello" in content.lower():
+        await message.channel.send("Hey there!")
+    else:
+        reply = llm.query(content)
+        await message.channel.send(reply)
+
+@client.event
+async def on_ready():
+    print(f"Bot is online as {client.user}.")
+
+@client.event
+async def on_message(message: discord.Message):
+    await handle_message(message)
+
+if __name__ == "__main__":
+    if not TOKEN:
+        raise RuntimeError("DISCORD_TOKEN environment variable not set")
+    client.run(TOKEN)
+

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -61,7 +61,9 @@ except Exception:  # noqa: E722 - broadly handle any import problem
 
 try:
     import pytesseract
-    pytesseract.pytesseract.tesseract_cmd = r"C:\\Program Files\\Tesseract-OCR\\tesseract.exe"
+    tess_cmd = os.getenv("TESSERACT_CMD")
+    if tess_cmd:
+        pytesseract.pytesseract.tesseract_cmd = tess_cmd
 except Exception:  # noqa: E722 - broadly handle any import problem
     pytesseract = None
 
@@ -77,7 +79,10 @@ class SystemMonitor:
         self._stop = threading.Event()
         self._screenshot_thread = None
 
-        self._last_clipboard = pyperclip.paste() if pyperclip else ""
+        try:
+            self._last_clipboard = pyperclip.paste() if pyperclip else ""
+        except Exception:
+            self._last_clipboard = ""
 
         if keyboard:
             keyboard.hook(self._on_keyboard)

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -1,0 +1,41 @@
+import asyncio
+from types import SimpleNamespace
+
+import discord_bot
+
+class DummyChannel:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, msg):
+        self.sent.append(msg)
+
+class DummyAuthor:
+    def __init__(self, bot=False):
+        self.bot = bot
+
+
+def test_handle_message_hello():
+    channel = DummyChannel()
+    message = SimpleNamespace(author=DummyAuthor(), content="hello there", channel=channel)
+    asyncio.run(discord_bot.handle_message(message))
+    assert channel.sent == ["Hey there!"]
+
+
+def test_handle_message_llm(monkeypatch):
+    channel = DummyChannel()
+    message = SimpleNamespace(author=DummyAuthor(), content="question", channel=channel)
+
+    class DummyLLM:
+        def __init__(self):
+            self.prompt = None
+        def query(self, prompt):
+            self.prompt = prompt
+            return "reply"
+
+    dummy = DummyLLM()
+    monkeypatch.setattr(discord_bot, "llm", dummy)
+    asyncio.run(discord_bot.handle_message(message))
+    assert dummy.prompt == "question"
+    assert channel.sent == ["reply"]
+

--- a/tests/test_system_monitor.py
+++ b/tests/test_system_monitor.py
@@ -96,6 +96,19 @@ class SystemMonitorTest(unittest.TestCase):
             monitor = sm.SystemMonitor()
             self.assertIsNone(sm.keyboard)
             self.assertIsNone(sm.mouse)
+    def test_import_without_tesseract_cmd(self):
+        import importlib
+        import system_monitor as sm
+        import os
+        os.environ.pop("TESSERACT_CMD", None)
+        importlib.reload(sm)
+        monitor = sm.SystemMonitor.__new__(sm.SystemMonitor)
+        import threading
+        monitor._stop = threading.Event()
+        monitor._screenshot_thread = None
+        self.assertTrue(hasattr(sm, "pytesseract"))
+        monitor.observer = None
+        self.assertIsNotNone(monitor)
         importlib.reload(sm)
 
 


### PR DESCRIPTION
## Summary
- implement a simple Discord bot hooked up to `OllamaClient`
- make tesseract path configurable via `TESSERACT_CMD`
- harden clipboard initialization in `SystemMonitor`
- mention optional env vars and how to run the Discord bot
- test Discord bot behaviour
- test optional tesseract path

## Testing
- `pip install -r requirements.txt` (minus `pywin32`)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d78f6aed48329a6088c54d9bce56e