### PR TITLE
Update requirements with keyboard and mouse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ pygetwindow
 pywinauto
 watchdog
 pywin32
+keyboard
+mouse


### PR DESCRIPTION
## Summary
- include `keyboard` and `mouse` packages in the dependencies list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_684d98afbf208329a15e128e768023b7