### PR TITLE
Fix Linux install issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ pyperclip
 pygetwindow
 pywinauto
 watchdog
-pywin32
 keyboard
 mouse

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -6,6 +6,7 @@ from collections import deque
 from datetime import datetime
 import json
 import threading
+import os
 
 import psutil
 try:


### PR DESCRIPTION
## Summary
- remove windows-only package `pywin32`
- import `os` in `system_monitor`
- run tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d9a1597bc832990bf51676297e0ba