### PR TITLE
Fix Discord bot message content

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ can complete login or any verification steps.
 ## Discord Bot
 Run `discord_bot.py` to enable a chat interface in Discord.
 Set the `DISCORD_TOKEN` environment variable with your bot token before running.
+The bot requires the **Message Content Intent** to read text in channels, so
+enable that permission in the Discord developer portal.
 
 ## License
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -9,6 +9,7 @@ from llm_client import OllamaClient
 TOKEN = os.getenv("DISCORD_TOKEN")
 
 intents = discord.Intents.default()
+intents.message_content = True  # allow reading message text
 client = discord.Client(intents=intents)
 llm = OllamaClient()
 


### PR DESCRIPTION
## Summary
- allow reading message text by enabling Discord message content intent
- mention the intent requirement in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684da04434848329a057406c912be2a3