### PR TITLE
Add status command to discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Set the `DISCORD_TOKEN` environment variable with your bot token before running.
 The bot requires the **Message Content Intent** to read text in channels, so
 enable that permission in the Discord developer portal.
 
+The bot also starts a small `SystemMonitor` thread. Type `!status` in any channel
+to see a summary of recent window titles, inputs, and clipboard changes.
+
 ## License
 
 This project is licensed under the terms of the [MIT License](LICENSE).

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -39,3 +39,13 @@ def test_handle_message_llm(monkeypatch):
     assert dummy.prompt == "question"
     assert channel.sent == ["reply"]
 
+
+def test_handle_message_status(monkeypatch):
+    channel = DummyChannel()
+    message = SimpleNamespace(author=DummyAuthor(), content="!status", channel=channel)
+
+    dummy_monitor = SimpleNamespace(summarize=lambda: "summary", capture_snapshot=lambda: None)
+    monkeypatch.setattr(discord_bot, "monitor", dummy_monitor)
+    asyncio.run(discord_bot.handle_message(message))
+    assert channel.sent == ["summary"]
+


### PR DESCRIPTION
## Summary
- monitor system activity in `discord_bot`
- support `!status` command
- document the new command
- test bot status output

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da675f3a88329874f97c46f895bfd