### PR TITLE
Add start/stop functions for monitor thread

### DIFF
--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -49,3 +49,9 @@ def test_handle_message_status(monkeypatch):
     asyncio.run(discord_bot.handle_message(message))
     assert channel.sent == ["summary"]
 
+
+def test_monitor_thread_start_stop():
+    t = discord_bot.start_monitor_thread()
+    assert t.is_alive()
+    discord_bot.stop_monitor_thread()
+


### PR DESCRIPTION
## Summary
- add start and stop helpers for the monitoring thread in `discord_bot`
- use these helpers in `__main__`
- test thread startup and shutdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa95b53148329962f2dd0f437861d