### PR TITLE
Update GUI default folder logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pytest
 
 You can optionally set the `TESSERACT_CMD` environment variable if Tesseract OCR is installed in a non-standard location.
 
-The GUI file browser defaults to `~/Documents/AI Assistant`. Set the `AI_ASSISTANT_FOLDER` environment variable or pass `folder_path` to `CodeAssistantGUI` to use a different directory.
+The GUI file browser defaults to `Path.home() / "Documents" / "AI Assistant"`. Set the `AI_ASSISTANT_FOLDER` environment variable or pass `folder_path` to `CodeAssistantGUI` to use a different directory.
 
 The `SystemMonitor` component now tracks:
 

--- a/gui_interface.py
+++ b/gui_interface.py
@@ -16,10 +16,13 @@ from PyQt5.QtGui import QIcon
 from PyQt5.QtCore import Qt, QTimer, QSize
 
 # Constants for file filtering and LLM API
-# Default folder is "~/Documents/AI Assistant" but can be overridden via the
-# AI_ASSISTANT_FOLDER environment variable or a constructor argument.
+# Default folder resolves to the user's Documents directory using ``pathlib``
+# but can be overridden via the ``AI_ASSISTANT_FOLDER`` environment variable or
+# a ``folder_path`` argument to ``CodeAssistantGUI``.
 DEFAULT_FOLDER = Path.home() / "Documents" / "AI Assistant"
-FOLDER_PATH = Path(os.getenv("AI_ASSISTANT_FOLDER", DEFAULT_FOLDER)).expanduser()
+
+env_folder = os.getenv("AI_ASSISTANT_FOLDER")
+FOLDER_PATH = Path(env_folder).expanduser() if env_folder else DEFAULT_FOLDER
 ALLOWED_EXTENSIONS = [".py", ".java", ".cpp", ".js", ".html", ".cs"]
 LLM_API_URL = "http://localhost:11434/api/chat"
 

--- a/tests/test_gui_interface.py
+++ b/tests/test_gui_interface.py
@@ -11,3 +11,11 @@ def test_default_folder_resolves(monkeypatch):
     importlib.reload(gui_interface)
     assert gui_interface.FOLDER_PATH == Path.home() / "Documents" / "AI Assistant"
 
+
+def test_env_override(monkeypatch, tmp_path):
+    pytest.importorskip("PyQt5")
+    monkeypatch.setenv("AI_ASSISTANT_FOLDER", str(tmp_path))
+    import gui_interface
+    importlib.reload(gui_interface)
+    assert gui_interface.FOLDER_PATH == tmp_path
+


### PR DESCRIPTION
## Summary
- use `Path.home()` to construct the default GUI folder
- allow overriding via `AI_ASSISTANT_FOLDER` or constructor arg
- document the path behaviour
- test default folder logic including env override

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684faa7e91408329b55b7254372e4fe3