### PR TITLE
Optimize ClippyAgent notifications

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -109,3 +109,27 @@ def test_loop_continues_with_reporter(tmp_path):
     assert reporter.count == 1
     assert window.last == "ok"
     agent.stop()
+
+
+def test_no_query_on_unchanged_snapshot(tmp_path):
+    window = DummyWindow()
+    agent = ClippyAgent(window, poll_interval=0, notify_interval=1000)
+    agent.monitor = _make_monitor(tmp_path)
+
+    class DummyLLM:
+        def __init__(self):
+            self.calls = 0
+
+        def query(self, prompt):
+            self.calls += 1
+            return "ok"
+
+    agent.llm = DummyLLM()
+
+    agent.start()
+    time.sleep(0.05)
+    first_calls = agent.llm.calls
+    time.sleep(0.05)
+    agent.stop()
+
+    assert first_calls == agent.llm.calls == 1


### PR DESCRIPTION
## Summary
- track last snapshot and last message time in `ClippyAgent`
- skip querying the LLM when system snapshot hasn't changed
- expose `notify_interval` to force occasional messages
- test that unchanged snapshots don't trigger new LLM queries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fb08af4fc8329b4c38f38996e3797