### PR TITLE
Limit messages when no significant change detected

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -57,7 +57,12 @@ class ClippyAgent:
             try:
                 snapshot = self.monitor.capture_snapshot()
                 now = time.time()
-                changed = snapshot != self._last_snapshot
+                if self._last_snapshot is None:
+                    changed = True
+                else:
+                    prev = {k: v for k, v in self._last_snapshot.items() if k != "timestamp"}
+                    curr = {k: v for k, v in snapshot.items() if k != "timestamp"}
+                    changed = curr != prev
                 timed_out = (
                     self.notify_interval is not None
                     and now - self._last_message_time >= self.notify_interval


### PR DESCRIPTION
## Summary
- fix `ClippyAgent` change detection logic so timestamps don't trigger constant updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fb352026083298f66970630b5a7aa