### PR TITLE
Update ClippyAgent to use contextual snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,21 @@ Enter to send it directly to the LLM. Replies accumulate in the floating window
 so you have a scrollable running log of the conversation. The window can now be
 resized like a normal application.
 
+Snapshots from the `SystemMonitor` are silently appended to the conversation as
+extra context. They no longer trigger automatic replies. To see a quick recap
+of the latest snapshot, type **summary** in the text box and the assistant will
+respond with a short overview.
+
 ### Custom system prompt
 
 `OllamaClient` now accepts a `system_prompt` argument. This optional string
 sets the initial system message used for every conversation. If omitted, the
 client defaults to "You are a helpful assistant." Passing a different value lets
 you customize the assistant's personality.
+
+Use `OllamaClient.add_context(text)` to append additional system messages
+without making an API request. `ClippyAgent` relies on this to feed each
+system snapshot into the conversation history.
 
 ## Memos and process scans
 

--- a/llm_client.py
+++ b/llm_client.py
@@ -19,6 +19,10 @@ class OllamaClient:
         self._messages: Deque[Dict[str, Any]] = deque(maxlen=memory)
         self._messages.append({"role": "system", "content": system_prompt})
 
+    def add_context(self, text: str) -> None:
+        """Append a system-level context message without querying the API."""
+        self._messages.append({"role": "system", "content": text})
+
     def query(self, prompt: str, timeout: int = 60) -> str:
         """Send a prompt and update conversation history."""
         self._messages.append({"role": "user", "content": prompt})

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -47,3 +47,9 @@ def test_stream_response_appends(monkeypatch):
 
     assert reply == "hello world"
     assert client._messages[-1] == {"role": "assistant", "content": "hello world"}
+
+
+def test_add_context():
+    client = OllamaClient()
+    client.add_context("extra")
+    assert client._messages[-1] == {"role": "system", "content": "extra"}


### PR DESCRIPTION
## Summary
- add `OllamaClient.add_context`
- feed snapshots as context in `ClippyAgent._loop`
- respond to `summary` command in `handle_text`
- document how to request summaries
- update tests for the new behavior

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbf07f73c83299537439ea2c8d209