### PR TITLE
Make notifications opt-in for ClippyAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ extra context. They no longer trigger automatic replies. To see a quick recap
 of the latest snapshot, type **summary** in the text box and the assistant will
 respond with a short overview.
 
+`ClippyAgent` normally sends short summaries periodically. Passing
+`notify_interval=None` when creating the agent disables this behavior so you
+don't see duplicate messages if another bot handles notifications.
+
 ### Custom system prompt
 
 `OllamaClient` now accepts a `system_prompt` argument. This optional string

--- a/agent.py
+++ b/agent.py
@@ -16,7 +16,7 @@ class ClippyAgent:
         window,
         poll_interval: int = 10,
         error_reporter: ErrorReporter | None = None,
-        notify_interval: int | None = 60,
+        notify_interval: int | None = None,
     ) -> None:
         self.window = window
         # Monitor the current directory for file changes as an example


### PR DESCRIPTION
## Summary
- default `notify_interval` to `None` in `ClippyAgent`
- document that `notify_interval=None` disables periodic summaries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc0294c208329b02dd9586b4cce9d