### PR TITLE
Fix conversation history for streamed responses

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -41,10 +41,9 @@ class OllamaClient:
                 except json.JSONDecodeError:
                     continue
             reply = "".join(parts)
-            self._messages.append({"role": "assistant", "content": reply})
-            return reply
+        else:
+            data = resp.json()
+            reply = data.get("message", {}).get("content", "")
 
-        data = resp.json()
-        reply = data.get("message", {}).get("content", "")
         self._messages.append({"role": "assistant", "content": reply})
         return reply

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -43,10 +43,13 @@ def test_stream_response_appends(monkeypatch):
     fake_response.raise_for_status.return_value = None
 
     with mock.patch("requests.post", return_value=fake_response):
+        start_len = len(client._messages)
         reply = client.query("hi")
 
     assert reply == "hello world"
     assert client._messages[-1] == {"role": "assistant", "content": "hello world"}
+    # user + assistant messages should be added
+    assert len(client._messages) == start_len + 2
 
 
 def test_add_context():


### PR DESCRIPTION
## Summary
- append streamed reply to conversation history after full assembly
- strengthen streaming test to verify history length

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc4e751cc83299c16b887fafc09d1