### PR TITLE
Update notify_interval docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ respond with a short overview.
 
 `ClippyAgent` normally sends short summaries periodically. Passing
 `notify_interval=None` when creating the agent disables this behavior so you
-don't see duplicate messages if another bot handles notifications.
+don't see duplicate messages if another bot handles notifications. The default
+is `None`, so periodic summaries are disabled unless you opt in with a custom
+interval.
 
 ### Custom system prompt
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -37,7 +37,7 @@ def _make_monitor(tmp_path):
 
 def test_handle_text_triggers_memo(tmp_path):
     window = DummyWindow()
-    agent = ClippyAgent(window)
+    agent = ClippyAgent(window, notify_interval=None)
     agent.monitor = _make_monitor(tmp_path)
 
     class DummyLLM:
@@ -54,7 +54,7 @@ def test_handle_text_triggers_memo(tmp_path):
 
 def test_loop_continues_on_error(tmp_path):
     window = DummyWindow()
-    agent = ClippyAgent(window, poll_interval=0)
+    agent = ClippyAgent(window, poll_interval=0, notify_interval=None)
     agent.monitor = _make_monitor(tmp_path)
 
     class FailingLLM:
@@ -89,7 +89,7 @@ def test_loop_continues_with_reporter(tmp_path):
             self.count += 1
 
     reporter = DummyReporter()
-    agent = ClippyAgent(window, poll_interval=0, error_reporter=reporter)
+    agent = ClippyAgent(window, poll_interval=0, error_reporter=reporter, notify_interval=None)
     agent.monitor = _make_monitor(tmp_path)
 
     class FailingLLM:
@@ -138,7 +138,7 @@ def test_no_query_on_unchanged_snapshot(tmp_path):
 
 def test_handle_text_summary(tmp_path):
     window = DummyWindow()
-    agent = ClippyAgent(window)
+    agent = ClippyAgent(window, notify_interval=None)
     agent.monitor = _make_monitor(tmp_path)
 
     snapshot = {"foo": "bar"}


### PR DESCRIPTION
## Summary
- clarify that `notify_interval=None` disables periodic summaries
- explicitly set `notify_interval` in agent tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc6fce9cc8329b665266dc212864b