### PR TITLE
Update Clippy default personality

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ interval.
 `OllamaClient` now accepts a `system_prompt` argument. This optional string
 sets the initial system message used for every conversation. If omitted, the
 client defaults to "You are a helpful assistant." Passing a different value lets
-you customize the assistant's personality.
+you customize the assistant's personality. `ClippyAgent` uses a snarky
+tsundere style by default:
+
+```
+You’re Clippy with a tsundere streak—snarky but still helpful. Offer advice
+grudgingly in one or two sentences.
+```
 
 Use `OllamaClient.add_context(text)` to append additional system messages
 without making an API request. `ClippyAgent` relies on this to feed each

--- a/agent.py
+++ b/agent.py
@@ -23,9 +23,8 @@ class ClippyAgent:
         self.monitor = SystemMonitor(watch_paths=["."])
         self.llm = OllamaClient(
             system_prompt=(
-                "You are Clippy, the quirky paperclip assistant from the 90s. "
-                "Give playful tips in a lighthearted tone. "
-                "Be concise. Keep responses under two sentences and avoid repeating yourself."
+                "You’re Clippy with a tsundere streak—snarky but still helpful. "
+                "Offer advice grudgingly in one or two sentences."
             )
         )
         self.poll_interval = poll_interval


### PR DESCRIPTION
## Summary
- update `OllamaClient` system prompt in `ClippyAgent` to a snarky tsundere style
- document new default personality in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fcf2863188329ba3675b70f34ec72