### PR TITLE
Enable command parsing in Discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Use `SystemMonitor.save_screen_memo()` to capture on-screen text and save it in 
 - `open <path>` launches a file or folder using the default application.
 - `close` attempts to close the active window (requires `pyautogui` or `pywinauto`).
 - `start <command>` spawns a new process via `subprocess`.
+- `close <title>` closes a window matching `title` when `pywinauto` is available.
 
 These helpers live in `system_controller.py`.
 
@@ -116,6 +117,8 @@ enable that permission in the Discord developer portal.
 
 The bot also starts a small `SystemMonitor` thread. Type `!status` in any channel
 to see a summary of recent window titles, inputs, and clipboard changes.
+It also recognizes simple phrases like `open <path>`, `start <cmd>`, and
+`close <title>` to control the host system directly.
 
 ## Optional packages for GUI and screenshot features
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -6,10 +6,12 @@ import os
 import threading
 import time
 import asyncio
+import re
 
 import discord
 from system_monitor import SystemMonitor
 import discord_agent
+import system_controller
 
 TOKEN = os.getenv("DISCORD_TOKEN")
 
@@ -64,6 +66,21 @@ async def handle_message(message: discord.Message) -> None:
     if lower == "!status":
         monitor.capture_snapshot()
         await message.channel.send(monitor.summarize())
+        return
+
+    m = re.match(r"open\s+(.+)", content, re.I)
+    if m:
+        system_controller.open_file(m.group(1).strip())
+        return
+
+    m = re.match(r"start\s+(.+)", content, re.I)
+    if m:
+        system_controller.start_process(m.group(1).strip())
+        return
+
+    m = re.match(r"close\s+(.+)", content, re.I)
+    if m:
+        system_controller.close_window_by_name(m.group(1).strip())
         return
 
     loop = asyncio.get_running_loop()

--- a/system_controller.py
+++ b/system_controller.py
@@ -47,6 +47,18 @@ def close_active_window():
     return False
 
 
+def close_window_by_name(name: str) -> bool:
+    """Close a window matching ``name`` using pywinauto when available."""
+    if Application:
+        try:
+            app = Application().connect(title_re=name)
+            app.top_window().close()
+            return True
+        except Exception:
+            pass
+    return False
+
+
 def start_process(cmd):
     """Start a new process using subprocess."""
     try:

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -88,3 +88,45 @@ def test_monitor_thread_start_stop():
     t = discord_bot.start_monitor_thread()
     assert t.is_alive()
     discord_bot.stop_monitor_thread()
+
+
+def test_handle_message_open_command(monkeypatch):
+    _reset_agents()
+    channel = DummyChannel()
+    message = SimpleNamespace(author=DummyAuthor(), content="open foo.txt", channel=channel)
+
+    calls = {}
+    monkeypatch.setattr(discord_bot.system_controller, 'open_file', lambda p: calls.setdefault('path', p))
+
+    asyncio.run(discord_bot.handle_message(message))
+
+    assert calls['path'] == 'foo.txt'
+    assert not discord_bot._agents
+
+
+def test_handle_message_start_command(monkeypatch):
+    _reset_agents()
+    channel = DummyChannel()
+    message = SimpleNamespace(author=DummyAuthor(), content="start echo hi", channel=channel)
+
+    calls = {}
+    monkeypatch.setattr(discord_bot.system_controller, 'start_process', lambda c: calls.setdefault('cmd', c))
+
+    asyncio.run(discord_bot.handle_message(message))
+
+    assert calls['cmd'] == 'echo hi'
+    assert not discord_bot._agents
+
+
+def test_handle_message_close_command(monkeypatch):
+    _reset_agents()
+    channel = DummyChannel()
+    message = SimpleNamespace(author=DummyAuthor(), content="close calc", channel=channel)
+
+    calls = {}
+    monkeypatch.setattr(discord_bot.system_controller, 'close_window_by_name', lambda n: calls.setdefault('name', n))
+
+    asyncio.run(discord_bot.handle_message(message))
+
+    assert calls['name'] == 'calc'
+    assert not discord_bot._agents

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -41,3 +41,22 @@ def test_start_process(monkeypatch):
     assert proc == 'proc'
     assert launched['cmd'] == 'echo hi'
     assert launched['shell']
+
+
+def test_close_window_by_name(monkeypatch):
+    calls = {}
+
+    class DummyWindow:
+        def close(self):
+            calls['closed'] = True
+
+    class DummyApp:
+        def connect(self, title_re=None):
+            calls['title'] = title_re
+            return SimpleNamespace(top_window=lambda: DummyWindow())
+
+    monkeypatch.setattr(system_controller, 'Application', DummyApp)
+
+    assert system_controller.close_window_by_name('Calculator')
+    assert calls['title'] == 'Calculator'
+    assert calls['closed']


### PR DESCRIPTION
## Summary
- detect basic command phrases in `discord_bot.handle_message`
- add helper `close_window_by_name` for closing windows via pywinauto
- document new control commands in README
- test the new helper and Discord bot logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fdb23417883299ed675ef168e6158