### PR TITLE
Implement close_window_by_name helper

### DIFF
--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -60,3 +60,23 @@ def test_close_window_by_name(monkeypatch):
     assert system_controller.close_window_by_name('Calculator')
     assert calls['title'] == 'Calculator'
     assert calls['closed']
+
+
+def test_close_window_by_name_psutil(monkeypatch):
+    terminations = []
+
+    class DummyProc:
+        def __init__(self, name):
+            self.info = {'name': name}
+
+        def terminate(self):
+            terminations.append(self.info['name'])
+
+    def fake_iter(attrs):
+        return [DummyProc('calc.exe'), DummyProc('notepad.exe')]
+
+    monkeypatch.setattr(system_controller, 'Application', None)
+    monkeypatch.setattr(system_controller, 'psutil', SimpleNamespace(process_iter=fake_iter))
+
+    assert system_controller.close_window_by_name('calc')
+    assert 'calc.exe' in terminations


### PR DESCRIPTION
## Summary
- implement `close_window_by_name` to close window or process by name
- add psutil import fallback
- update and extend unit tests for new behaviour

## Testing
- `pip install psutil requests discord`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fdc2e3ddc8329a13cc450ada0cc81