### PR TITLE
Fix multiple process termination

### DIFF
--- a/system_controller.py
+++ b/system_controller.py
@@ -68,13 +68,16 @@ def close_window_by_name(app_name: str) -> bool:
             pass
 
     if psutil:
+        terminated = False
         for proc in psutil.process_iter(["name"]):
             try:
                 if app_name.lower() in (proc.info.get("name") or "").lower():
                     proc.terminate()
-                    return True
+                    terminated = True
             except Exception:
                 continue
+        if terminated:
+            return True
 
     return False
 

--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -73,10 +73,16 @@ def test_close_window_by_name_psutil(monkeypatch):
             terminations.append(self.info['name'])
 
     def fake_iter(attrs):
-        return [DummyProc('calc.exe'), DummyProc('notepad.exe')]
+        return [
+            DummyProc('calc.exe'),
+            DummyProc('calc-helper.exe'),
+            DummyProc('notepad.exe'),
+        ]
 
     monkeypatch.setattr(system_controller, 'Application', None)
     monkeypatch.setattr(system_controller, 'psutil', SimpleNamespace(process_iter=fake_iter))
 
     assert system_controller.close_window_by_name('calc')
     assert 'calc.exe' in terminations
+    assert 'calc-helper.exe' in terminations
+    assert 'notepad.exe' not in terminations


### PR DESCRIPTION
## Summary
- close all processes with a matching name in `system_controller.close_window_by_name`
- test closing multiple matching processes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fe4734c588329a4c4e4791f97525c