### PR TITLE
Add close active window command

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -78,6 +78,10 @@ async def handle_message(message: discord.Message) -> None:
         system_controller.start_process(m.group(1).strip())
         return
 
+    if lower == "close":
+        system_controller.close_active_window()
+        return
+
     m = re.match(r"close\s+(.+)", content, re.I)
     if m:
         system_controller.close_window_by_name(m.group(1).strip())

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -130,3 +130,17 @@ def test_handle_message_close_command(monkeypatch):
 
     assert calls['name'] == 'calc'
     assert not discord_bot._agents
+
+
+def test_handle_message_close_active_window(monkeypatch):
+    _reset_agents()
+    channel = DummyChannel()
+    message = SimpleNamespace(author=DummyAuthor(), content="close", channel=channel)
+
+    calls = {}
+    monkeypatch.setattr(discord_bot.system_controller, 'close_active_window', lambda: calls.setdefault('called', True))
+
+    asyncio.run(discord_bot.handle_message(message))
+
+    assert calls.get('called')
+    assert not discord_bot._agents


### PR DESCRIPTION
## Summary
- handle `close` command in `discord_bot.handle_message`
- unit test for `close` invoking `close_active_window`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe56fa01c8329a1304d3342a2c302