### PR TITLE
Add test for closing multiple processes

### DIFF
--- a/tests/test_system_controller.py
+++ b/tests/test_system_controller.py
@@ -86,3 +86,27 @@ def test_close_window_by_name_psutil(monkeypatch):
     assert 'calc.exe' in terminations
     assert 'calc-helper.exe' in terminations
     assert 'notepad.exe' not in terminations
+
+
+def test_close_window_by_name_multiple_matches(monkeypatch):
+    terminations = []
+
+    class DummyProc:
+        def __init__(self, name):
+            self.info = {'name': name}
+
+        def terminate(self):
+            terminations.append(self.info['name'])
+
+    def fake_iter(attrs):
+        return [
+            DummyProc('foo.exe'),
+            DummyProc('foo.exe'),
+            DummyProc('bar.exe'),
+        ]
+
+    monkeypatch.setattr(system_controller, 'Application', None)
+    monkeypatch.setattr(system_controller, 'psutil', SimpleNamespace(process_iter=fake_iter))
+
+    assert system_controller.close_window_by_name('foo')
+    assert terminations == ['foo.exe', 'foo.exe']


### PR DESCRIPTION
## Summary
- ensure `close_window_by_name` handles multiple matching processes
- add regression test `test_close_window_by_name_multiple_matches`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe690636c8329b65519f622995b3b