### PR TITLE
Add logging and confirmations to Discord bot

### DIFF
--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -101,6 +101,7 @@ def test_handle_message_open_command(monkeypatch):
     asyncio.run(discord_bot.handle_message(message))
 
     assert calls['path'] == 'foo.txt'
+    assert channel.sent == ["Opened."]
     assert not discord_bot._agents
 
 
@@ -115,6 +116,7 @@ def test_handle_message_start_command(monkeypatch):
     asyncio.run(discord_bot.handle_message(message))
 
     assert calls['cmd'] == 'echo hi'
+    assert channel.sent == ["Process started."]
     assert not discord_bot._agents
 
 
@@ -129,6 +131,7 @@ def test_handle_message_close_command(monkeypatch):
     asyncio.run(discord_bot.handle_message(message))
 
     assert calls['name'] == 'calc'
+    assert channel.sent == ["Closed calc."]
     assert not discord_bot._agents
 
 
@@ -143,4 +146,5 @@ def test_handle_message_close_active_window(monkeypatch):
     asyncio.run(discord_bot.handle_message(message))
 
     assert calls.get('called')
+    assert channel.sent == ["Closed active window."]
     assert not discord_bot._agents

--- a/tests/test_discord_commands.py
+++ b/tests/test_discord_commands.py
@@ -44,6 +44,7 @@ async def _assert_system_command(monkeypatch, content, attr, arg):
     await discord_bot.handle_message(message)
 
     assert calls.get("arg") == arg
+    assert channel.sent
     assert not discord_bot._agents
 
 


### PR DESCRIPTION
## Summary
- configure logging in `discord_bot`
- log system command calls and results
- send simple confirmation messages for system commands
- update related tests for new confirmations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe84989c48329895a506e0584363e