### PR TITLE
Expand Discord commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ The bot requires the **Message Content Intent** to read text in channels, so
 enable that permission in the Discord developer portal.
 
 The bot also starts a small `SystemMonitor` thread. Type `!status` in any channel
-to see a summary of recent window titles, inputs, and clipboard changes.
-It also recognizes simple phrases like `open <path>`, `start <cmd>`, and
-`close <title>` to control the host system directly. Use `start` for applications
+or ask “what’s on the screen”/“screen status” to see a summary of recent window
+titles, inputs, and clipboard changes. It also recognizes simple phrases like
+`open <path>`, `start <cmd>`, and `close <title>` to control the host system
+directly even when the words appear mid-sentence. Use `start` for applications
 (`start chrome`) and `open` for files or folders. `close <title>` attempts to
 terminate all matching processes when possible.
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -66,12 +66,16 @@ async def handle_message(message: discord.Message) -> None:
     content = message.content
     logging.info("Command received: %s", content)
     lower = content.lower().strip()
-    if lower == "!status":
+    if (
+        lower == "!status"
+        or "screen status" in lower
+        or re.search(r"what[’']?s on the screen", lower)
+    ):
         monitor.capture_snapshot()
         await message.channel.send(monitor.summarize())
         return
 
-    m = re.match(r"open\s+(.+)", content, re.I)
+    m = re.search(r"\bopen\s+(.+)", content, re.I)
     if m:
         path = m.group(1).strip()
         logging.info("Calling open_file(%s)", path)
@@ -80,7 +84,7 @@ async def handle_message(message: discord.Message) -> None:
         await message.channel.send("Opened." if success else "Failed to open.")
         return
 
-    m = re.match(r"start\s+(.+)", content, re.I)
+    m = re.search(r"\bstart\s+(.+)", content, re.I)
     if m:
         cmd = m.group(1).strip()
         logging.info("Calling start_process(%s)", cmd)
@@ -91,7 +95,7 @@ async def handle_message(message: discord.Message) -> None:
         )
         return
 
-    if lower == "close":
+    if lower.strip() == "close":
         logging.info("Calling close_active_window()")
         success = system_controller.close_active_window()
         logging.info("close_active_window returned %s", success)
@@ -100,7 +104,7 @@ async def handle_message(message: discord.Message) -> None:
         )
         return
 
-    m = re.match(r"close\s+(.+)", content, re.I)
+    m = re.search(r"\bclose\s+(.+)", content, re.I)
     if m:
         name = m.group(1).strip()
         logging.info("Calling close_window_by_name(%s)", name)

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -84,6 +84,17 @@ def test_handle_message_status(monkeypatch):
     assert channel.sent == ["summary"]
 
 
+def test_handle_message_status_synonyms(monkeypatch):
+    _reset_agents()
+    dummy_monitor = SimpleNamespace(summarize=lambda: "summary", capture_snapshot=lambda: None)
+    monkeypatch.setattr(discord_bot, "monitor", dummy_monitor)
+    for text in ["what's on the screen?", "please show screen status"]:
+        channel = DummyChannel()
+        message = SimpleNamespace(author=DummyAuthor(), content=text, channel=channel)
+        asyncio.run(discord_bot.handle_message(message))
+        assert channel.sent == ["summary"]
+
+
 def test_monitor_thread_start_stop():
     t = discord_bot.start_monitor_thread()
     assert t.is_alive()
@@ -93,7 +104,7 @@ def test_monitor_thread_start_stop():
 def test_handle_message_open_command(monkeypatch):
     _reset_agents()
     channel = DummyChannel()
-    message = SimpleNamespace(author=DummyAuthor(), content="open foo.txt", channel=channel)
+    message = SimpleNamespace(author=DummyAuthor(), content="please open foo.txt", channel=channel)
 
     calls = {}
     monkeypatch.setattr(discord_bot.system_controller, 'open_file', lambda p: calls.setdefault('path', p))
@@ -108,7 +119,7 @@ def test_handle_message_open_command(monkeypatch):
 def test_handle_message_start_command(monkeypatch):
     _reset_agents()
     channel = DummyChannel()
-    message = SimpleNamespace(author=DummyAuthor(), content="start echo hi", channel=channel)
+    message = SimpleNamespace(author=DummyAuthor(), content="could you start echo hi", channel=channel)
 
     calls = {}
     monkeypatch.setattr(discord_bot.system_controller, 'start_process', lambda c: calls.setdefault('cmd', c))
@@ -123,7 +134,7 @@ def test_handle_message_start_command(monkeypatch):
 def test_handle_message_close_command(monkeypatch):
     _reset_agents()
     channel = DummyChannel()
-    message = SimpleNamespace(author=DummyAuthor(), content="close calc", channel=channel)
+    message = SimpleNamespace(author=DummyAuthor(), content="please close calc", channel=channel)
 
     calls = {}
     monkeypatch.setattr(discord_bot.system_controller, 'close_window_by_name', lambda n: calls.setdefault('name', n))


### PR DESCRIPTION
## Summary
- relax open/start/close regex patterns in Discord bot
- treat "what's on the screen" and "screen status" as `!status`
- update tests for new phrasing
- document additional bot commands

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fecc879348329adcfec75e71c7189