### PR TITLE
Implement window enumeration in SystemMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The `SystemMonitor` component now tracks:
 - Clipboard changes in real time.
 - Keyboard and mouse activity.
 - Optional file modifications using `watchdog`.
+- `SystemMonitor.list_open_windows()` enumerates titles of all visible windows
+  using `pygetwindow` when available. It falls back to `pywinauto` on Windows,
+  `wmctrl -l` on Linux, or `osascript` on macOS.
 
 If the `keyboard` or `mouse` packages are unavailable, `SystemMonitor` falls
 back to local `keyboard_stub` and `mouse_stub` modules that provide no-op


### PR DESCRIPTION
## Summary
- add `list_open_windows` to gather titles from pygetwindow or fallbacks
- record open windows in snapshots and summaries
- expose window list in `to_json`
- document new helper in README
- unit tests for enumeration logic and snapshot integration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d41bfe488329a6160fae367d576a