### PR TITLE
Add Gmail search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ directly even when the words appear mid-sentence. Use `start` for applications
 (`start chrome`) and `open` for files or folders. `close <title>` attempts to
 terminate all matching processes when possible.
 
+Type `!gmail <query>` in any channel to search your Gmail inbox. The bot
+authenticates using OAuth credentials stored locally. Set your Google client ID
+in the `GOOGLE_CLIENT_ID` environment variable and ensure the credentials file
+(`gmail_token.json` by default) is kept somewhere secure.
+
 ## Optional packages for GUI and screenshot features
 
 The minimal `requirements.txt` keeps dependencies small. Install these extras to enable the graphical interface and screenshot capture:

--- a/gmail_utils.py
+++ b/gmail_utils.py
@@ -1,0 +1,61 @@
+import os
+from pathlib import Path
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from google.auth.transport.requests import Request
+
+SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
+
+
+def get_service(client_id_env: str = "GOOGLE_CLIENT_ID"):
+    """Return an authenticated Gmail API service instance.
+
+    The OAuth client ID should be provided via the ``GOOGLE_CLIENT_ID``
+    environment variable. OAuth credentials are loaded from the path
+    specified by ``GMAIL_TOKEN_FILE`` or ``gmail_token.json`` by default.
+    """
+    client_id = os.getenv(client_id_env)
+    if not client_id:
+        raise RuntimeError(f"{client_id_env} environment variable not set")
+
+    token_file = os.getenv("GMAIL_TOKEN_FILE", "gmail_token.json")
+
+    if not Path(token_file).exists():
+        raise RuntimeError(f"OAuth token file not found: {token_file}")
+
+    creds = Credentials.from_authorized_user_file(token_file, SCOPES)
+
+    if creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+        Path(token_file).write_text(creds.to_json())
+
+    return build("gmail", "v1", credentials=creds)
+
+
+def search_messages(service, query: str):
+    """Return a list of ``(id, subject)`` tuples matching ``query``."""
+    results = service.users().messages().list(userId="me", q=query).execute()
+    messages = results.get("messages", [])
+    output = []
+    for msg in messages:
+        mid = msg.get("id")
+        if not mid:
+            continue
+        meta = (
+            service.users()
+            .messages()
+            .get(
+                userId="me",
+                id=mid,
+                format="metadata",
+                metadataHeaders=["Subject"],
+            )
+            .execute()
+        )
+        headers = meta.get("payload", {}).get("headers", [])
+        subject = next(
+            (h["value"] for h in headers if h.get("name") == "Subject"), ""
+        )
+        output.append((mid, subject))
+    return output

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 psutil
 requests
 discord.py
+google-api-python-client
+google-auth-oauthlib

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -191,3 +191,20 @@ def test_handle_message_ignore_open_in_sentence(monkeypatch):
 
     assert 'path' not in calls
     assert channel.sent == ["reply"]
+
+def test_handle_message_gmail(monkeypatch):
+    _reset_agents()
+    channel = DummyChannel()
+    message = SimpleNamespace(author=DummyAuthor(), content="!gmail foo", channel=channel)
+
+    monkeypatch.setattr(discord_bot.gmail_utils, "get_service", lambda: "svc")
+    monkeypatch.setattr(
+        discord_bot.gmail_utils,
+        "search_messages",
+        lambda svc, q: [("1", "sub1"), ("2", "sub2")] if svc == "svc" and q == "foo" else [],
+    )
+
+    asyncio.run(discord_bot.handle_message(message))
+
+    assert "sub1" in channel.sent[0]
+    assert "sub2" in channel.sent[0]

--- a/tests/test_gmail_utils.py
+++ b/tests/test_gmail_utils.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+import builtins
+import gmail_utils
+
+
+def test_get_service(monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "cid")
+    monkeypatch.setenv("GMAIL_TOKEN_FILE", "token.json")
+
+    calls = {}
+
+    def fake_exists(self):
+        calls["path"] = str(self)
+        return True
+
+    class DummyCreds:
+        expired = False
+        refresh_token = None
+
+        def refresh(self, request):
+            calls["refreshed"] = True
+
+    fake_creds = DummyCreds()
+
+    def fake_from_file(path, scopes):
+        calls["from_file"] = path
+        calls["scopes"] = scopes
+        return fake_creds
+
+    def fake_build(api, version, credentials):
+        calls["credentials"] = credentials
+        return "svc"
+
+    monkeypatch.setattr(gmail_utils.Path, "exists", fake_exists)
+    monkeypatch.setattr(gmail_utils.Credentials, "from_authorized_user_file", staticmethod(fake_from_file))
+    monkeypatch.setattr(gmail_utils, "build", fake_build)
+    monkeypatch.setattr(gmail_utils, "Request", object)
+
+    service = gmail_utils.get_service()
+    assert service == "svc"
+    assert calls["credentials"] is fake_creds
+    assert calls["from_file"] == "token.json"
+    assert calls["scopes"] == ["https://www.googleapis.com/auth/gmail.readonly"]
+
+
+def test_search_messages():
+    class DummyMessages:
+        def __init__(self):
+            self.queries = []
+
+        def list(self, userId="me", q=None):
+            self.queries.append(q)
+            return SimpleNamespace(execute=lambda: {"messages": [{"id": "1"}, {"id": "2"}]})
+
+        def get(self, userId="me", id=None, format=None, metadataHeaders=None):
+            return SimpleNamespace(execute=lambda: {"payload": {"headers": [{"name": "Subject", "value": f"sub {id}"}]}})
+
+    class DummyUsers:
+        def __init__(self):
+            self.msg = DummyMessages()
+
+        def messages(self):
+            return self.msg
+
+    class DummyService:
+        def __init__(self):
+            self.users_inst = DummyUsers()
+
+        def users(self):
+            return self.users_inst
+
+    svc = DummyService()
+    res = gmail_utils.search_messages(svc, "foo")
+    assert svc.users_inst.msg.queries == ["foo"]
+    assert res == [("1", "sub 1"), ("2", "sub 2")]


### PR DESCRIPTION
## Summary
- add google Gmail dependencies
- implement `gmail_utils` with basic OAuth helper and search
- integrate new `!gmail` command in Discord bot
- document Gmail integration
- add unit tests for Gmail helpers and Discord bot command

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d68a73908329849e7a7095637c3e