### PR TITLE
Handle Gmail errors in Discord bot

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -120,9 +120,16 @@ async def handle_message(message: discord.Message) -> None:
     m = re.match(r"!gmail\s+(.+)", content, re.I)
     if m:
         query = m.group(1).strip()
-        service = gmail_utils.get_service()
-        loop = asyncio.get_running_loop()
-        results = await loop.run_in_executor(None, gmail_utils.search_messages, service, query)
+        try:
+            service = gmail_utils.get_service()
+            loop = asyncio.get_running_loop()
+            results = await loop.run_in_executor(
+                None, gmail_utils.search_messages, service, query
+            )
+        except Exception as exc:
+            logging.exception("Error searching Gmail")
+            await message.channel.send(f"Error searching Gmail: {exc}")
+            return
         if results:
             lines = "\n".join(f"- {sub}" for _, sub in results)
             await message.channel.send(f"Found {len(results)} messages:\n{lines}")

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -208,3 +208,21 @@ def test_handle_message_gmail(monkeypatch):
 
     assert "sub1" in channel.sent[0]
     assert "sub2" in channel.sent[0]
+
+
+def test_handle_message_gmail_error(monkeypatch):
+    _reset_agents()
+    channel = DummyChannel()
+    message = SimpleNamespace(author=DummyAuthor(), content="!gmail bar", channel=channel)
+
+    monkeypatch.setattr(discord_bot.gmail_utils, "get_service", lambda: "svc")
+
+    def boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(discord_bot.gmail_utils, "search_messages", boom)
+
+    asyncio.run(discord_bot.handle_message(message))
+
+    assert channel.sent
+    assert "Error" in channel.sent[0]


### PR DESCRIPTION
## Summary
- handle exceptions from Gmail service functions in the Discord bot
- add a regression test to ensure Gmail errors don't crash the bot

## Testing
- `pytest tests/test_discord_bot.py::test_handle_message_gmail_error -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850e2d94cb483298c5f44bbafc745d0